### PR TITLE
Fix Reader and Writer for lower-case objects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val `teleproto` = project
   .settings(Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings): _*)
   .settings(
     name := "teleproto",
-    version := "1.12.0",
+    version := "1.12.1",
     versionScheme := Some("early-semver"),
     libraryDependencies ++= Seq(
       library.scalaPB            % "protobuf;compile",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.5.3

--- a/src/main/scala/io/moia/protos/teleproto/ReaderImpl.scala
+++ b/src/main/scala/io/moia/protos/teleproto/ReaderImpl.scala
@@ -366,7 +366,7 @@ class ReaderImpl(val c: blackbox.Context) extends FormatImpl {
 
     val (cases, compatibility) = subTypes.unzip
     val emptyCase = for (protobufClass <- protobufSubClasses.get(EmptyOneOf) if !modelSubclasses.contains(EmptyOneOf))
-      yield cq"""`${objectReferenceTo(protobufClass)}` => $mapping.PbFailure("Oneof field is empty!")"""
+      yield cq"""_: ${objectReferenceTo(protobufClass)}.type => $mapping.PbFailure("Oneof field is empty!")"""
 
     val reader = c.freshName(TermName("reader"))
     val result = q"""{
@@ -419,11 +419,11 @@ class ReaderImpl(val c: blackbox.Context) extends FormatImpl {
     val cases = for {
       (optionName, modelOption) <- modelOptions.toList
       protobufOption            <- protobufOptions.get(optionName)
-    } yield cq"`${objectReferenceTo(protobufOption)}` => $mapping.PbSuccess(${objectReferenceTo(modelOption)})"
+    } yield cq"_: ${objectReferenceTo(protobufOption)}.type => $mapping.PbSuccess(${objectReferenceTo(modelOption)})"
 
     val invalidCase = for (protobufOption <- protobufOptions.get(InvalidEnum) if !modelOptions.contains(InvalidEnum)) yield {
       val reference = objectReferenceTo(protobufOption)
-      cq"""`$reference` => $mapping.PbFailure(s"Enumeration value $${$reference} is invalid!")"""
+      cq"""_: $reference.type => $mapping.PbFailure(s"Enumeration value $${$reference} is invalid!")"""
     }
 
     val reader = c.freshName(TermName("reader"))

--- a/src/main/scala/io/moia/protos/teleproto/WriterImpl.scala
+++ b/src/main/scala/io/moia/protos/teleproto/WriterImpl.scala
@@ -162,12 +162,8 @@ class WriterImpl(val c: blackbox.Context) extends FormatImpl {
       val cons =
         q"""${protobufCompanion.asTerm}.apply(..${for ((name, (arg, _)) <- namedArguments) yield q"$name = $arg"})"""
 
-      // a type cast is needed due to type inferencer limitations
-      val innerCompatibilities =
-        for ((_, (_, innerCompatibility)) <- namedArguments)
-          yield innerCompatibility.asInstanceOf[Compatibility]
-
-      val compatibility = innerCompatibilities.foldRight(ownCompatibility)(_.merge(_))
+      val innerCompatibilities = for ((_, (_, innerCompatibility)) <- namedArguments) yield innerCompatibility
+      val compatibility        = innerCompatibilities.foldRight(ownCompatibility)(_.merge(_))
 
       val result =
         q"""
@@ -329,7 +325,7 @@ class WriterImpl(val c: blackbox.Context) extends FormatImpl {
     val cases = for {
       (optionName, protobufOption) <- protobufOptions.toList
       modelOption                  <- modelOptions.get(optionName)
-    } yield cq"`${objectReferenceTo(modelOption)}` => ${objectReferenceTo(protobufOption)}"
+    } yield cq"_: ${objectReferenceTo(modelOption)}.type => ${objectReferenceTo(protobufOption)}"
 
     val writer = c.freshName(TermName("writer"))
     val result = q"""{

--- a/src/test/scala/io/moia/protos/teleproto/ProtocolBuffersRoundTripTest.scala
+++ b/src/test/scala/io/moia/protos/teleproto/ProtocolBuffersRoundTripTest.scala
@@ -17,7 +17,7 @@ class ProtocolBuffersRoundTripTest extends UnitTest with ScalaCheckPropertyCheck
   val modelWriter = VersionedModelWriter[Int, Meal](version -> food.Meal)
 
   val colorGen: Gen[Color] =
-    Gen.oneOf(Color.Red, Color.Orange, Color.Yellow, Color.Pink, Color.Blue)
+    Gen.oneOf(Color.Red, Color.orange, Color.Yellow, Color.pink, Color.Blue)
 
   val fruitGen: Gen[Fruit] = for {
     name  <- Gen.alphaStr
@@ -65,9 +65,9 @@ object ProtocolBuffersRoundTripTest {
   sealed trait Color
   object Color {
     case object Red    extends Color
-    case object Orange extends Color
+    case object orange extends Color
     case object Yellow extends Color
-    case object Pink   extends Color
+    case object pink   extends Color
     case object Blue   extends Color
   }
 


### PR DESCRIPTION
It looks like backquotes don't work correctly



#### Has the version number been increased?
 - [x] Yes! (or not but it was intended to not increase it)