### PR TITLE
feat: Add PbResult.toEither

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val `teleproto` = project
   .settings(Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings): _*)
   .settings(
     name          := "teleproto",
-    version       := "2.0.1",
+    version       := "2.1.0",
     versionScheme := Some("early-semver"),
     libraryDependencies ++= Seq(
       library.scalaPB            % "protobuf;compile",
@@ -151,18 +151,7 @@ lazy val scapegoatSettings = Seq(
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts := Set("io.moia" %% "teleproto" % "2.0.0"),
-  mimaBinaryIssueFilters ++= Seq(
-    // No binary compatibility guarantees for macro implementations (they run at compile time).
-    ProblemFilters.exclude[Problem]("io.moia.protos.teleproto.FormatImpl*"),
-    ProblemFilters.exclude[Problem]("io.moia.protos.teleproto.MigrationImpl*"),
-    ProblemFilters.exclude[Problem]("io.moia.protos.teleproto.ReaderImpl*"),
-    ProblemFilters.exclude[Problem]("io.moia.protos.teleproto.WriterImpl*"),
-    // PbResult is a sealed trait so linking from Scala should be fine.
-    // Also, this method was added before introducing MiMa.
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.moia.protos.teleproto.PbResult.toOption"),
-    // Writer.Mapped was an unused private class.
-    ProblemFilters.exclude[MissingClassProblem]("io.moia.protos.teleproto.Writer$Mapped")
-  )
+  mimaBinaryIssueFilters ++= Seq()
 )
 
 Test / PB.targets      := Seq(scalapb.gen(flatPackage = false) -> (Test / sourceManaged).value)

--- a/build.sbt
+++ b/build.sbt
@@ -151,7 +151,10 @@ lazy val scapegoatSettings = Seq(
 
 lazy val mimaSettings = Seq(
   mimaPreviousArtifacts := Set("io.moia" %% "teleproto" % "2.0.0"),
-  mimaBinaryIssueFilters ++= Seq()
+  mimaBinaryIssueFilters ++= Seq(
+    // Method was added in 2.1.0
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("io.moia.protos.teleproto.PbResult.toEither")
+  )
 )
 
 Test / PB.targets      := Seq(scalapb.gen(flatPackage = false) -> (Test / sourceManaged).value)

--- a/src/main/scala/io/moia/protos/teleproto/PbResult.scala
+++ b/src/main/scala/io/moia/protos/teleproto/PbResult.scala
@@ -40,6 +40,8 @@ sealed trait PbResult[+T] {
   def toTry: Try[T]
 
   def toOption: Option[T]
+
+  def toEither: Either[Seq[(String, String)], T]
 }
 
 object PbResult {
@@ -82,6 +84,8 @@ final case class PbSuccess[T](value: T) extends PbResult[T] {
   def toTry: Try[T] = Success(get)
 
   def toOption: Option[T] = Some(get)
+
+  override def toEither: Right[Seq[(String, String)], T] = Right(value)
 }
 
 /** Models the failure to read a Protocol Buffers case class into business model type `T`. Provides error messages for one or more paths,
@@ -116,6 +120,8 @@ final case class PbFailure(errors: Seq[(String, String)]) extends PbResult[Nothi
   def toTry: Try[Nothing] = Failure(new Exception(toString))
 
   def toOption: Option[Nothing] = None
+
+  override def toEither: Left[Seq[(String, String)], Nothing] = Left(errors)
 }
 
 object PbFailure {

--- a/src/main/scala/io/moia/protos/teleproto/PbResult.scala
+++ b/src/main/scala/io/moia/protos/teleproto/PbResult.scala
@@ -69,21 +69,21 @@ final case class PbSuccess[T](value: T) extends PbResult[T] {
   val isSuccess = true
   val isError   = false
 
-  def get: T = value
+  override def get: T = value
 
-  def getOrElse[U >: T](t: => U): U = value
+  override def getOrElse[U >: T](t: => U): U = value
 
-  def map[B](f: T => B): PbResult[B] = PbSuccess(f(value))
+  override def map[B](f: T => B): PbResult[B] = PbSuccess(f(value))
 
-  def flatMap[B](f: T => PbResult[B]): PbResult[B] = f(value)
+  override def flatMap[B](f: T => PbResult[B]): PbResult[B] = f(value)
 
-  def orElse[U >: T](that: => PbResult[U]): PbResult[U] = this
+  override def orElse[U >: T](that: => PbResult[U]): PbResult[U] = this
 
   override def withPathPrefix(prefix: String): PbSuccess[T] = this
 
-  def toTry: Try[T] = Success(get)
+  override def toTry: Try[T] = Success(get)
 
-  def toOption: Option[T] = Some(get)
+  override def toOption: Option[T] = Some(get)
 
   override def toEither: Right[Seq[(String, String)], T] = Right(value)
 }
@@ -101,15 +101,15 @@ final case class PbFailure(errors: Seq[(String, String)]) extends PbResult[Nothi
   val isSuccess = false
   val isError   = true
 
-  def get: Nothing = throw new NoSuchElementException(toString)
+  override def get: Nothing = throw new NoSuchElementException(toString)
 
-  def getOrElse[U >: Nothing](t: => U): U = t
+  override def getOrElse[U >: Nothing](t: => U): U = t
 
-  def map[B](f: Nothing => B): PbResult[B] = this.asInstanceOf[PbResult[B]]
+  override def map[B](f: Nothing => B): PbResult[B] = this.asInstanceOf[PbResult[B]]
 
-  def flatMap[B](f: Nothing => PbResult[B]): PbResult[B] = this.asInstanceOf[PbResult[B]]
+  override def flatMap[B](f: Nothing => PbResult[B]): PbResult[B] = this.asInstanceOf[PbResult[B]]
 
-  def orElse[U](that: => PbResult[U]): PbResult[U] = that
+  override def orElse[U](that: => PbResult[U]): PbResult[U] = that
 
   override def withPathPrefix(prefix: String): PbFailure =
     PbFailure(for ((path, message) <- errors) yield (prefix + path, message))
@@ -117,9 +117,9 @@ final case class PbFailure(errors: Seq[(String, String)]) extends PbResult[Nothi
   override def toString: String =
     errors.map(e => s"${e._1} ${e._2}".trim).mkString(" ")
 
-  def toTry: Try[Nothing] = Failure(new Exception(toString))
+  override def toTry: Try[Nothing] = Failure(new Exception(toString))
 
-  def toOption: Option[Nothing] = None
+  override def toOption: Option[Nothing] = None
 
   override def toEither: Left[Seq[(String, String)], Nothing] = Left(errors)
 }

--- a/src/test/scala/io/moia/protos/teleproto/PbResultTest.scala
+++ b/src/test/scala/io/moia/protos/teleproto/PbResultTest.scala
@@ -49,6 +49,10 @@ class PbResultTest extends UnitTest {
     "be converted to Success with toTry" in {
       PbSuccess("success").toTry shouldBe Success("success")
     }
+
+    "be converted to Right with toEither" in {
+      PbSuccess("success").toEither shouldBe Right("success")
+    }
   }
 
   "PbFailure" should {
@@ -63,6 +67,10 @@ class PbResultTest extends UnitTest {
 
     "be converted to Failure with toTry" in {
       PbFailure("error").toTry.failure.exception.getMessage shouldBe "error"
+    }
+
+    "be converted to Left with toEither" in {
+      PbFailure("/path", "error").toEither shouldBe Left(List(("/path", "error")))
     }
   }
 }


### PR DESCRIPTION
Adding a `toEither` method to `PbResult` which returns `Right` for `PbSuccess` and `Left` for `PbFailure`.

Also removing outdated warning suppressions for Mima.

#### Has the version number been increased?
 - [x] Yes! (or not but it was intended to not increase it)