### PR TITLE
Update various library dependencies.

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version        = 3.5.9
+version        = 3.6.1
 runner.dialect = scala213
 align.preset   = more
 maxColumn      = 140

--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val library = new {
     val scalaCheck         = "1.17.0"
     val scalaTest          = "3.2.15"
     val scalaTestPlusCheck = "3.2.2.0"
-    val scapeGoat          = "1.4.15"
+    val scapeGoat          = "2.0.0"
   }
 
   val scalaPB            = "com.thesamet.scalapb" %% "scalapb-runtime" % Version.scalaPB
@@ -66,7 +66,7 @@ lazy val commonSettings = Seq.concat(
 
 lazy val compilerSettings = Seq(
   scalaVersion                                                                     := crossScalaVersions.value.head,
-  crossScalaVersions                                                               := List("2.13.8", "2.12.16"),
+  crossScalaVersions                                                               := List("2.13.10", "2.12.17"),
   Compile / packageBin / mappings += (ThisBuild / baseDirectory).value / "LICENSE" -> "LICENSE",
   scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 12)) => scalacOptions_2_12
@@ -79,7 +79,8 @@ lazy val scalacOptions_2_12 = Seq(
   "-unchecked",
   "-deprecation",
   "-language:_",
-  "-target:jvm-1.8",
+  "-release",
+  "8",
   "-encoding",
   "UTF-8",
   "-Xfatal-warnings",
@@ -96,7 +97,8 @@ lazy val scalacOptions_2_13 = Seq(
   "-unchecked",
   "-deprecation",
   "-language:_",
-  "-target:jvm-1.8",
+  "-release",
+  "8",
   "-encoding",
   "UTF-8",
   "-Xfatal-warnings",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.7.1
+sbt.version=1.7.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 // Formatting in scala
 // See .scalafmt.conf for configuration details.
 // Formatting takes place before the project is compiled.
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 
 // Use git in sbt, show git prompt and use versions from git.
 // sbt> git <your git command>
@@ -21,7 +21,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-license-report" % "1.2.0")
 // Uses protoc to generate code from proto files. This SBT plugin is meant supercede sbt-protobuf and sbt-scalapb.
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.11"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.12"
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "5.9.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"    % "3.9.15")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -23,7 +23,7 @@ addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.6")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.11"
 
-addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "5.7.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header"      % "5.9.0")
 addSbtPlugin("org.xerial.sbt"    % "sbt-sonatype"    % "3.9.15")
 addSbtPlugin("com.dwijnand"      % "sbt-dynver"      % "4.1.1")
 addSbtPlugin("com.github.sbt"    % "sbt-pgp"         % "2.2.1")

--- a/src/main/scala-2.13/io/moia/protos/teleproto/VersionSpecific.scala
+++ b/src/main/scala-2.13/io/moia/protos/teleproto/VersionSpecific.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 MOIA GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.moia.protos.teleproto
 
 import scala.reflect.macros.blackbox

--- a/src/main/scala/io/moia/protos/teleproto/TestData.scala
+++ b/src/main/scala/io/moia/protos/teleproto/TestData.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 MOIA GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.moia.protos.teleproto
 
 import java.time.Instant


### PR DESCRIPTION
Today I closed the old dependency update PRs in this repo, hoping that
a manual trigger of the steward would re-open them, and merge them automatically,
after our the changes from https://github.com/moia-oss/teleproto/commit/066e8207bf7418f01e12116364e4078aec1c41ec. But what happened instead was that no new
dependency updates PRs are created, because the steward detects the closed PRs
and that blocks it somehow.

For that reason, these versions need manual update now. They should henceforth
get back to being updated automatically.

Signed-off-by: Ignacio Lucero <ignacio.lucero@moia.io>