### PR TITLE
Revert "Upgrade scala-reflect from 2.12.17 to 2.13.10"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val commonSettings = Seq.concat(
 
 lazy val compilerSettings = Seq(
   scalaVersion                                                                     := crossScalaVersions.value.head,
-  crossScalaVersions                                                               := List("2.13.10", "2.13.10"),
+  crossScalaVersions                                                               := List("2.13.10", "2.12.17"),
   Compile / packageBin / mappings += (ThisBuild / baseDirectory).value / "LICENSE" -> "LICENSE",
   scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, 12)) => scalacOptions_2_12


### PR DESCRIPTION
Reverts moia-oss/teleproto#235

For some reason that automated PR changed the version for cross-compilation to Scala 2.12...