### PR TITLE
Add an implicit derivation for Reader[Seq[P], Seq[M]].

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ lazy val `teleproto` = project
   .settings(Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings): _*)
   .settings(
     name          := "teleproto",
-    version       := "2.3.0",
+    version       := "2.4.0",
     versionScheme := Some("early-semver"),
     libraryDependencies ++= Seq(
       library.scalaPB            % "protobuf;compile",

--- a/src/main/scala/io/moia/protos/teleproto/Reader.scala
+++ b/src/main/scala/io/moia/protos/teleproto/Reader.scala
@@ -188,6 +188,11 @@ object Reader extends LowPriorityReads {
       Try(PbSuccess(LocalTime.parse(protobuf))).getOrElse(PbFailure("Value must be a local time in ISO format."))
   }
 
+  /* Given a Reader from P to M, it provides an automatic derivation for a Reader from Seq[P] to Seq[M].
+   */
+  implicit def sequenceReader[P, M](implicit reader: Reader[P, M]): Reader[Seq[P], Seq[M]] =
+    instance { protobuf => sequence[Seq, P, M](protobuf, "") }
+
   /** Tries to read a map of Protobuf key/values to a sorted map of Scala key/values if reader exists between both types and an ordering is
     * defined on the Scala key.
     */


### PR DESCRIPTION
This seems useful in some situations: given a `Reader[P, V]`, we can provide a `Reader[Seq[P], Seq[M]]`.

We could also make it more generic with something like `F[_] <: Iterable[_]` or something along those lines.



#### Has the version number been increased?
 - [x] Yes! (or not but it was intended to not increase it)