### PR TITLE
Remove crossbuild config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -67,32 +67,9 @@ lazy val commonSettings = Seq.concat(
 )
 
 lazy val compilerSettings = Seq(
-  scalaVersion                                                                     := crossScalaVersions.value.head,
-  crossScalaVersions                                                               := List("2.13.14", "2.13.14"),
+  scalaVersion                                                                     := "2.13.14",
   Compile / packageBin / mappings += (ThisBuild / baseDirectory).value / "LICENSE" -> "LICENSE",
-  scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
-    case Some((2, 12)) => scalacOptions_2_12
-    case Some((2, 13)) => scalacOptions_2_13
-    case _             => Nil
-  })
-)
-
-lazy val scalacOptions_2_12 = Seq(
-  "-unchecked",
-  "-deprecation",
-  "-language:_",
-  "-release",
-  "8",
-  "-encoding",
-  "UTF-8",
-  "-Xfatal-warnings",
-  "-Ywarn-unused-import",
-  "-Yno-adapted-args",
-  "-Ywarn-dead-code",
-  "-Ywarn-inaccessible",
-  "-Ywarn-infer-any",
-  "-Ywarn-nullary-override",
-  "-Ywarn-nullary-unit"
+  scalacOptions ++= scalacOptions_2_13
 )
 
 lazy val scalacOptions_2_13 = Seq(


### PR DESCRIPTION
Scapegoat messed that up some weeks ago and now fails. None of us internally at MOIA are on Scala 2.12 anymore, so I think it's fine to drop support for 2.12. (We should instead work on a Scala 3 compatible release soon.)

#### Has the version number been increased?
 - [ ] Yes! (or not but it was intended to not increase it)